### PR TITLE
Add unstated-next support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.6.4",
+    "unstated-next": "^1.1.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,24 @@
 import React, { useState } from 'react';
 
-import './App.css';
-import { AppProvider } from './context/app.context';
-import { MyDiv } from './components/mydiv.component';
-import { BadConsumer } from './components/badconsumer.component';
+import { AppProviderNext } from "./context/app.context-next";
 
 function App() {
     const [error, setError] = useState(false);
     return (
         <>
+      {/** Grants ability to override defaults without additional typing */}
+      <AppProviderNext.Provider
+        initialState={{ data: [100], prop1: 0, prop2: "N/A" }}
+      >
             <AppProvider>
-                <MyDiv className='border' iterate>
-                    Custom Generic FC type inside the component allows children (React removed this in React 18 to avoid unhandled props that may accidently be passed in) and
-                    standard props based on a base html element type like className
+          <MyDiv className="border" iterate>
+            Custom Generic FC type inside the component allows children (React
+            removed this in React 18 to avoid unhandled props that may
+            accidently be passed in) and standard props based on a base html
+            element type like className
                 </MyDiv>
             </AppProvider>
+      </AppProviderNext.Provider>
             <button onClick={() => setError(!error)}>Cause a context crash</button>
             {error && <BadConsumer />}
         </>

--- a/src/components/badconsumer.component.tsx
+++ b/src/components/badconsumer.component.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useAppContext } from '../context/app.context';
-
+import { useAppContextNext} from '../context/app.context-next';
 export const BadConsumer: RA.FC = () => {
-    const [appState, appDispatch] = useAppContext();
+    // const [appState, appDispatch] = useAppContext();
+    const appStateNext = useAppContextNext(); // Still Blows up
     return <div>This is going to blow up when put outside the provider, but log an error.</div>;
 };

--- a/src/components/mydiv.component.tsx
+++ b/src/components/mydiv.component.tsx
@@ -1,24 +1,35 @@
 import React from 'react';
 import { useAppContext } from '../context/app.context';
-
+import {useAppContextNext } from '../context/app.context-next';
 interface MyDivProps {
     iterate?: boolean;
 }
 
 export const MyDiv: RA.FC<MyDivProps, true, HTMLDivElement> = ({ children, iterate, ...props }) => {
     const [appState, appDispatch] = useAppContext();
+    const appStateNext = useAppContextNext();
     return (
         <div {...props}>
             {children}
             <p>Last Render: {Date.now()}</p>
             <p>Data: {JSON.stringify(appState.data)}</p>
+            <p>DataNext: {JSON.stringify(appStateNext.data)}</p>
 
             {/** Payload types are restricted based on the action type */}
-            <button onClick={() => appDispatch({ type: 'addData' })}>Add Data</button>
-            {iterate && <button onClick={() => appDispatch({ type: 'add', payload: 1 })}>Iterate Data</button>}
+            <button onClick={() => {
+                appStateNext.addData(1)
+                appStateNext.slowAdd(1)
+                appDispatch({ type: 'addData', payload: 1 });
+            }}>Add Data</button>
+            {iterate && <button onClick={() => {
+                appStateNext.iterateData();
+                appDispatch({ type: 'add', payload: 1 });
+            }}>Iterate Data</button>}
 
             {/** Will show a console error, but wont rerender */}
+            {/** This can't happen with unstated. Method won't exist to call */}
             <button onClick={() => appDispatch({ type: 'Uhh Ohh' as any })}>Make a Mistake (check console, this wont rerender)</button>
         </div>
     );
 };
+

--- a/src/context/app.context-next.tsx
+++ b/src/context/app.context-next.tsx
@@ -1,0 +1,48 @@
+import { useCallback, useState } from "react";
+import { createContainer, useContainer } from "unstated-next";
+function AppStateNext(
+  initialState: { prop1: number; prop2: string; data: number[] } = {
+    prop1: -1,
+    prop2: "",
+    data: [],
+  }
+) {
+  // State can be managed and udpated internally based on Async Events
+  // Allows for "Thunk" or "Saga" based state management within context. Something reducers are not made for
+  const [appState, setAppState] = useState(initialState);
+
+  /* Named functions vs fuzzy strings. Functions can be memoized and use additional hooks. useCallback for ex. 
+	ex: useCallback
+	  - Functions are automatically typed. No AppAction type needed.
+  */
+  const addData = useCallback((value: number) => {
+    setAppState((prev) => ({
+      ...appState,
+      data: [...prev.data, value].sort((a, b) => a - b),
+    }));
+  }, [appState]);
+
+  const iterateData = () => {
+    setAppState((prev) => ({ ...appState, data: prev.data.map((n) => n + 1) }));
+  };
+
+  const slowAdd = (value: number) => { 
+    setTimeout(() => {
+      // Internal function calling supported
+      addData(value);
+    }, 1000);
+  }
+
+  // Context is automatially typed by return result. No additional Interfaces or Types required
+  return {
+    ...appState,
+    addData,
+    slowAdd,
+    iterateData,
+  };
+}
+
+export const AppProviderNext = createContainer(AppStateNext);
+export function useAppContextNext() {
+  return useContainer(AppProviderNext);
+}

--- a/src/context/app.context.tsx
+++ b/src/context/app.context.tsx
@@ -31,6 +31,7 @@ export const useAppContext = () => {
 const reducer = (state: AppState, action: AppAction) => {
     const newState = action.storeOnly ? state : { ...state };
 
+  // You can't refactor fuzzy strings. You'd have to create constants for each action type
     switch (action.type) {
         case 'prop1':
         case 'prop2':


### PR DESCRIPTION
Thank you for following up on this. Here are the updates that I would consider when using React Context to streamline the code you need to write.

**Added Library**
https://github.com/jamiebuilds/unstated-next

Key Benefits

1. Type inference. No predefined `interface` or `type`  required. Everything is self typed by inputs and outputs: Ex: https://github.com/jsheely/context_example/blob/feat/unstated-next/src/context/app.context.tsx#L3
2. Functional components allow for `async` operations for updating state when required. This combines the ability of `thunk` or `saga` into a single abstraction. Ex: https://github.com/jsheely/context_example/blob/feat/unstated-next/src/context/app.context-next.tsx#L29
3. No fuzzy strings for reducers. Typically one would create constants for these but it's another interface to define when you already have functions names you can use. Ex. https://github.com/jsheely/context_example/blob/feat/unstated-next/src/context/app.context.tsx#L36 vs https://github.com/jsheely/context_example/blob/feat/unstated-next/src/context/app.context-next.tsx#L18
4. Less confusing definition for variables. `action.payload` can be anything depending on the situation. With functions it's clear what the variables are and their intent. Ex: See #3 examples
5. Provider initial state can be easily initialized by the app consumer and doesn't have to be re-typed and re-initialized. Also allows `intialState` to be required if default value is not provided. Ex. https://github.com/jsheely/context_example/blob/feat/unstated-next/src/App.tsx#L11

